### PR TITLE
Update app-generator.ts

### DIFF
--- a/packages/generator/src/generators/app-generator.ts
+++ b/packages/generator/src/generators/app-generator.ts
@@ -236,9 +236,11 @@ export class AppGenerator extends Generator<AppGeneratorOptions> {
     const commitSpinner = log.spinner(log.withBrand("Committing your app")).start()
     const commands: Array<[string, string[], object]> = [
       ["git", ["add", "."], {stdio: "ignore"}],
+      ["git", ["config", "user.name", "'The Blitz.js CLI'"], {stdio: "ignore"}],
+      ["git", ["config", "user.email", "'noop@blitzjs.com'"], {stdio: "ignore"}],
       [
         "git",
-        ["commit", "--no-gpg-sign", "--no-verify", "-m", "New baby Blitz app!"],
+        ["commit", "--no-gpg-sign", "--no-verify", "-m", "'New Blitz App Initialized.'"],
         {stdio: "ignore", timeout: 10000},
       ],
     ]

--- a/packages/generator/test/generators/app-generator.test.ts
+++ b/packages/generator/test/generators/app-generator.test.ts
@@ -112,6 +112,18 @@ describe("AppGenerator", () => {
 
     expect(spawn.sync).toHaveBeenCalledWith("git", ["add", "."], {stdio: "ignore"})
   })
+  
+    it("calls git config user.name", async () => {
+    await generator.run()
+
+    expect(spawn.sync).toHaveBeenCalledWith("git", ["config", "user.name","The Blitz.js CLI"], {stdio: "ignore"})
+  })
+  
+      it("calls git config user.email", async () => {
+    await generator.run()
+
+    expect(spawn.sync).toHaveBeenCalledWith("git", ["config", "user.email","noop@blitzjs.com"], {stdio: "ignore"})
+  })
 
   it("calls git commit", async () => {
     await generator.run()
@@ -119,7 +131,7 @@ describe("AppGenerator", () => {
     //
     expect(spawn.sync).toHaveBeenCalledWith(
       "git",
-      ["commit", "--no-gpg-sign", "--no-verify", "-m", "New baby Blitz app!"],
+      ["commit", "--no-gpg-sign", "--no-verify", "-m", "Initialize a Brand New Blitz.js App."],
       {
         stdio: "ignore",
         timeout: 10000,


### PR DESCRIPTION
Add user.name and user.email default config flags to initial commit, so initial commit is shown as being created by Blitz.js app with email noop@blitzjs.com

Closes:  ##1843

### What are the changes and their implications?

Add config user.name and user.email flags with blitz values to app-generator.ts.

As a result these values are used on initial commit if a user does not have a global git config set.

### Checklist

- [x] Changes covered by tests (tests added if needed)
- [x] PR submitted to [blitzjs.com](https://github.com/blitz-js/blitzjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
